### PR TITLE
feat: add generic environment resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## 1.0.0
 
-- Initial version.
+- Initial version providing generic compile-time environment resolution.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,57 @@
-<!-- 
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
-
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages). 
-
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages). 
--->
-
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+`envx` resolves compile-time environment configuration for Dart and Flutter
+applications.
 
 ## Features
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+- Custom resolver to map a `String` environment value to any enum.
+- Compile-time `APP_ENV` (or custom) variable with a configurable default.
+- Access the current configuration or any specific environment's config.
 
 ## Getting started
 
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
+Define your environment enum, configuration class, and resolver. Then create an
+`Envx` instance with your configuration map.
 
 ## Usage
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder. 
-
 ```dart
-const like = 'sample';
+import 'package:envx/envx.dart';
+
+enum AppEnvironment { development, production }
+
+class ExampleConfig {
+  const ExampleConfig(this.baseUrl);
+  final String baseUrl;
+}
+
+AppEnvironment parseEnv(String value) {
+  switch (value) {
+    case 'production':
+    case 'prod':
+      return AppEnvironment.production;
+    default:
+      return AppEnvironment.development;
+  }
+}
+
+void main() {
+  const configs = <AppEnvironment, ExampleConfig>{
+    AppEnvironment.development: ExampleConfig('https://dev.example.com'),
+    AppEnvironment.production: ExampleConfig('https://example.com'),
+  };
+
+  final envx = Envx<AppEnvironment, ExampleConfig>(
+    values: configs,
+    resolver: parseEnv,
+  );
+
+  final ExampleConfig? config = envx.environment;
+  print('Base URL: ${config?.baseUrl}');
+}
 ```
 
 ## Additional information
 
-TODO: Tell users more about the package: where to find more information, how to 
-contribute to the package, how to file issues, what response they can expect 
-from the package authors, and more.
+This library is synchronous and maintains no global state beyond compile-time
+constants.
+

--- a/example/envx_example.dart
+++ b/example/envx_example.dart
@@ -1,6 +1,33 @@
 import 'package:envx/envx.dart';
 
+enum AppEnvironment { development, production }
+
+class ExampleConfig {
+  const ExampleConfig(this.baseUrl);
+  final String baseUrl;
+}
+
+AppEnvironment parseEnv(String value) {
+  switch (value) {
+    case 'production':
+    case 'prod':
+      return AppEnvironment.production;
+    default:
+      return AppEnvironment.development;
+  }
+}
+
 void main() {
-  var awesome = Awesome();
-  print('awesome: ${awesome.isAwesome}');
+  const configs = <AppEnvironment, ExampleConfig>{
+    AppEnvironment.development: ExampleConfig('https://dev.example.com'),
+    AppEnvironment.production: ExampleConfig('https://example.com'),
+  };
+
+  final envx = Envx<AppEnvironment, ExampleConfig>(
+    values: configs,
+    resolver: parseEnv,
+  );
+
+  final ExampleConfig? config = envx.environment;
+  print('Base URL: ${config?.baseUrl}');
 }

--- a/lib/envx.dart
+++ b/lib/envx.dart
@@ -1,8 +1,10 @@
-/// Support for doing something awesome.
+/// Provides compile-time environment configuration resolution.
 ///
-/// More dartdocs go here.
+/// Create an [Envx] instance with your own environment enum and configuration
+/// class to retrieve environment-specific values at runtime.
+///
+/// This library contains only synchronous utilities, so a cancellation token is
+/// unnecessary.
 library;
 
-export 'src/envx_base.dart';
-
-// TODO: Export any libraries intended for clients of this package.
+export 'src/envx_base.dart' show Envx, EnvironmentResolver;

--- a/lib/src/envx_base.dart
+++ b/lib/src/envx_base.dart
@@ -1,6 +1,64 @@
-// TODO: Put public facing types in this file.
+/// Resolves a raw environment [value] into an enumeration instance.
+///
+/// Used by [Envx] to map the compile-time environment string into the
+/// application's environment type.
+typedef EnvironmentResolver<E extends Object> = E Function(String value);
 
-/// Checks if you are awesome. Spoiler: you are.
-class Awesome {
-  bool get isAwesome => true;
+/// Provides access to compile-time environment configuration.
+///
+/// Create an instance with your own environment enum and configuration class.
+/// Retrieve the current configuration via [environment] or fetch a specific
+/// one with [configFor].
+///
+/// The API is synchronous and holds no resources, therefore a cancellation
+/// token is unnecessary.
+class Envx<E extends Object, C extends Object> {
+  /// Creates a new [Envx] store.
+  ///
+  /// [values] must contain at least one entry. The map is used to look up the
+  /// configuration for a given environment. [resolver] translates the
+  /// compile-time string into the environment enum.
+  ///
+  /// The [key] parameter specifies the compile-time variable name. It defaults
+  /// to [defaultEnvironmentKey]. [defaultValue] is used when the compile-time
+  /// variable is absent. It defaults to [defaultEnvironmentValue].
+  const Envx({
+    required Map<E, C> values,
+    required EnvironmentResolver<E> resolver,
+    String key = defaultEnvironmentKey,
+    String defaultValue = defaultEnvironmentValue,
+  }) : _values = values,
+       _resolver = resolver,
+       _key = key,
+       _defaultValue = defaultValue;
+
+  /// Name of the compile-time environment variable.
+  static const String defaultEnvironmentKey = 'APP_ENV';
+
+  /// Default value used when the compile-time variable is missing.
+  static const String defaultEnvironmentValue = 'development';
+
+  final Map<E, C> _values;
+  final EnvironmentResolver<E> _resolver;
+  final String _key;
+  final String _defaultValue;
+
+  /// Returns the environment constant derived from the compile-time define.
+  E currentEnvironment() {
+    final String raw = String.fromEnvironment(
+      _key,
+      defaultValue: _defaultValue,
+    );
+    return _resolver(raw);
+  }
+
+  /// Retrieves the configuration for [environment].
+  ///
+  /// Returns `null` when no configuration is registered for [environment].
+  C? configFor(E environment) {
+    return _values[environment];
+  }
+
+  /// Current configuration based on [currentEnvironment].
+  C? get environment => configFor(currentEnvironment());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: envx
-description: A starting point for Dart libraries or applications.
+description: Compile-time environment configuration resolver for Dart and Flutter.
 version: 1.0.0
 # repository: https://github.com/my_org/my_repo
 

--- a/test/envx_test.dart
+++ b/test/envx_test.dart
@@ -1,16 +1,55 @@
 import 'package:envx/envx.dart';
 import 'package:test/test.dart';
 
+enum AppEnvironment { development, staging, production }
+
+class SimpleConfig {
+  const SimpleConfig(this.name);
+  final String name;
+}
+
+AppEnvironment parseEnv(String value) {
+  switch (value) {
+    case 'staging':
+      return AppEnvironment.staging;
+    case 'production':
+    case 'prod':
+      return AppEnvironment.production;
+    default:
+      return AppEnvironment.development;
+  }
+}
+
 void main() {
-  group('A group of tests', () {
-    final awesome = Awesome();
+  const configs = <AppEnvironment, SimpleConfig>{
+    AppEnvironment.development: SimpleConfig('dev'),
+    AppEnvironment.staging: SimpleConfig('stage'),
+    AppEnvironment.production: SimpleConfig('prod'),
+  };
 
-    setUp(() {
-      // Additional setup goes here.
-    });
+  final envx = Envx<AppEnvironment, SimpleConfig>(
+    values: configs,
+    resolver: parseEnv,
+  );
 
-    test('First Test', () {
-      expect(awesome.isAwesome, isTrue);
-    });
+  test('returns default environment configuration', () {
+    final SimpleConfig? current = envx.environment;
+    expect(current?.name, 'dev');
+  });
+
+  test('configFor retrieves specified environment', () {
+    final SimpleConfig? staging = envx.configFor(AppEnvironment.staging);
+    expect(staging?.name, 'stage');
+  });
+
+  test('supports custom key and default value', () {
+    final custom = Envx<AppEnvironment, SimpleConfig>(
+      values: configs,
+      resolver: parseEnv,
+      key: 'CUSTOM_ENV',
+      defaultValue: 'production',
+    );
+    final AppEnvironment env = custom.currentEnvironment();
+    expect(env, AppEnvironment.production);
   });
 }


### PR DESCRIPTION
## Summary
- add generic `Envx` for compile-time environment resolution
- allow custom resolver, key, and default value
- expose helpers to fetch current and specific environment configs

## Testing
- `dart analyze`
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_68c02e3cf9c88325be7a2cc95b95f55e