### PR TITLE
refactor: provide environment factory

### DIFF
--- a/example/envx_example.dart
+++ b/example/envx_example.dart
@@ -7,27 +7,31 @@ class ExampleConfig {
   final String baseUrl;
 }
 
-AppEnvironment parseEnv(String value) {
+AppEnvironment? parseEnv(String value) {
   switch (value) {
     case 'production':
     case 'prod':
       return AppEnvironment.production;
-    default:
+    case 'development':
+    case 'dev':
       return AppEnvironment.development;
+    default:
+      return null;
   }
 }
 
-void main() {
-  const configs = <AppEnvironment, ExampleConfig>{
-    AppEnvironment.development: ExampleConfig('https://dev.example.com'),
-    AppEnvironment.production: ExampleConfig('https://example.com'),
-  };
-
-  final envx = Envx<AppEnvironment, ExampleConfig>(
-    values: configs,
+Future<void> main() async {
+  final env = Environment<AppEnvironment, ExampleConfig>(
+    configs: {
+      AppEnvironment.development: () async =>
+          const ExampleConfig('https://dev.example.com'),
+      AppEnvironment.production: () async =>
+          const ExampleConfig('https://example.com'),
+    },
     resolver: parseEnv,
+    defaultEnvironment: AppEnvironment.development,
   );
 
-  final ExampleConfig? config = envx.environment;
+  final config = await env.current(fallbackValue: 'prod');
   print('Base URL: ${config?.baseUrl}');
 }

--- a/lib/envx.dart
+++ b/lib/envx.dart
@@ -1,10 +1,86 @@
-/// Support for doing something awesome.
+// Public entry points for the envx environment resolver.
+//
+// Provides the [Environment] factory to configure and query typed
+// environments without relying on global state.
+
+export 'src/default_resolvers.dart';
+export 'src/types.dart';
+
+import 'src/environment_registry.dart';
+import 'src/environment_service.dart';
+import 'src/types.dart';
+
+/// Creates typed environments and exposes configuration lookups.
 ///
-/// More dartdocs go here.
-library;
+/// Generic over:
+/// - [K]: environment key type, e.g. `AppEnvironment` or `String`.
+/// - [C]: configuration type, e.g. `AppConfig`.
+class Environment<K, C> {
+  Environment._(this._service);
 
+  /// Factory to build an [Environment] instance.
+  ///
+  /// Parameters:
+  /// - [configs]: mapping from environment keys to async configuration builders.
+  ///   May be empty; lookups will then yield `null`.
+  /// - [defaultEnvironment]: used when resolution fails.
+  /// - [resolver]: optional function translating a raw string to a key.
+  ///   When omitted and [K] is `String`, an identity resolver is used.
+  ///   For other types without a resolver, unknown values fall back to
+  ///   [defaultEnvironment].
+  /// - [defineKey]: compile-time define key. Defaults to
+  ///   [EnvxConstants.defaultDefineKey].
+  factory Environment({
+    required Map<K, Future<C> Function()> configs,
+    required K defaultEnvironment,
+    EnvResolver<K>? resolver,
+    String defineKey = EnvxConstants.defaultDefineKey,
+  }) {
+    final registry = EnvironmentRegistry<K, C>(
+      configs: configs,
+      defaultEnvironment: defaultEnvironment,
+    );
 
+    EnvResolver<K> effectiveResolver;
+    if (resolver != null) {
+      effectiveResolver = resolver;
+    } else if (K == String) {
+      effectiveResolver = (input) => input as K;
+    } else {
+      effectiveResolver = (_) => null;
+    }
 
-// Read from compile-time define (e.g., --dart-define=APP_ENV=prod):
-final currentEnvironment = env.resolveFromBuildDefine();               // -> AppEnvironment.production
-final environment = env.configFromBuildDefine();                    // -> EnvironmentConfig for production
+    final service = EnvironmentService<K, C>(
+      registry: registry,
+      resolver: effectiveResolver,
+      defineKey: defineKey,
+    );
+
+    return Environment._(service);
+  }
+
+  final EnvironmentService<K, C> _service;
+
+  /// Resolve the current environment from the build define and return its
+  /// configuration.
+  ///
+  /// [fallbackValue] provides a value when the define is empty, useful for
+  /// tests or platforms without `--dart-define` support.
+  ///
+  /// No cancellation token: configuration builders are expected to complete
+  /// quickly and cannot be cancelled.
+  Future<C>? current({String? fallbackValue}) {
+    final env = _service.resolveFromBuildDefine(fallbackValue: fallbackValue);
+    return _service.configFor(env);
+  }
+
+  /// Returns the environment key resolved from the build define.
+  K currentKey({String? fallbackValue}) =>
+      _service.resolveFromBuildDefine(fallbackValue: fallbackValue);
+
+  /// Resolve [raw] via the resolver and return its configuration.
+  Future<C>? getEnvironment(String raw) => _service.configFromString(raw);
+
+  /// Directly fetch configuration for [env].
+  Future<C>? getEnvironmentByKey(K env) => _service.configFor(env);
+}

--- a/lib/src/environment_registry.dart
+++ b/lib/src/environment_registry.dart
@@ -1,16 +1,16 @@
-/// Holds the mapping between an environment enum and its configuration.
+/// Holds the mapping between an environment key and its configuration.
 ///
 /// Generic over:
-/// - [E]: your enum type, e.g. `AppEnvironment`
+/// - [K]: your environment key type, e.g. `AppEnvironment` or `String`
 /// - [C]: your configuration class/type, e.g. `EnvironmentConfig`
 ///
 /// This class never throws. When a lookup misses, it returns `null` or
 /// falls back to the default config via `tryGetOrDefault`.
-class EnvironmentRegistry<E extends Enum, C> {
-  final Map<E, Future<C> Function()> _configs;
+class EnvironmentRegistry<K, C> {
+  final Map<K, Future<C> Function()> _configs;
 
   /// The environment to fall back to when resolution fails.
-  final E defaultEnvironment;
+  final K defaultEnvironment;
 
   /// The default configuration (may be `null` if [defaultEnvironment] is not present in [configs]).
   final Future<C> Function()? _defaultConfig;
@@ -18,27 +18,38 @@ class EnvironmentRegistry<E extends Enum, C> {
   /// Creates a registry. If [defaultEnvironment] is not present in [configs],
   /// `_defaultConfig` will be `null`, which means `tryGetOrDefault` returns `null`
   /// when both the requested and default configs are missing.
-  const EnvironmentRegistry._(this._configs, this.defaultEnvironment, this._defaultConfig);
+  const EnvironmentRegistry._(
+    this._configs,
+    this.defaultEnvironment,
+    this._defaultConfig,
+  );
 
   /// Factory with validation at the boundary; never throws.
   ///
   /// - If [configs] is empty, still returns a registry (all lookups become `null`).
   /// - If [defaultEnvironment] is absent in [configs], the registry stays valid,
   ///   but `getDefault()` will return `null`.
-  factory EnvironmentRegistry({required Map<E, Future<C> Function()> configs, required E defaultEnvironment}) {
+  factory EnvironmentRegistry({
+    required Map<K, Future<C> Function()> configs,
+    required K defaultEnvironment,
+  }) {
     final defaultConfig = configs[defaultEnvironment];
-    return EnvironmentRegistry._(Map.unmodifiable(configs), defaultEnvironment, defaultConfig);
+    return EnvironmentRegistry._(
+      Map.unmodifiable(configs),
+      defaultEnvironment,
+      defaultConfig,
+    );
   }
 
   /// Returns the configuration for [env] or `null` if missing.
-  Future<C>? tryGet(E env) {
+  Future<C>? tryGet(K env) {
     if (_configs.isEmpty) return null;
     return _configs[env]?.call();
   }
 
   /// Returns the configuration for [env], or the default configuration if
   /// the requested one is missing. May still be `null` if neither exists.
-  Future<C>? tryGetOrDefault(E env) {
+  Future<C>? tryGetOrDefault(K env) {
     final hit = tryGet(env);
     if (hit != null) return hit;
     return _defaultConfig?.call();
@@ -48,5 +59,5 @@ class EnvironmentRegistry<E extends Enum, C> {
   Future<C>? getDefault() => _defaultConfig?.call();
 
   /// Returns the set of supported environments in this registry.
-  Iterable<E> supportedEnvironments() => _configs.keys;
+  Iterable<K> supportedEnvironments() => _configs.keys;
 }

--- a/lib/src/environment_service.dart
+++ b/lib/src/environment_service.dart
@@ -7,12 +7,12 @@ import 'environment_registry.dart';
 /// compile-time define via `String.fromEnvironment`.
 ///
 /// No-throw design: unrecognized values fall back to [registry.defaultEnvironment].
-class EnvironmentService<E extends Enum, C> {
+class EnvironmentService<K, C> {
   /// Where we keep configs and the default environment.
-  final EnvironmentRegistry<E, C> registry;
+  final EnvironmentRegistry<K, C> registry;
 
-  /// How to parse a raw string value into the enum.
-  final EnvResolver<E> resolver;
+  /// How to parse a raw string value into the environment key.
+  final EnvResolver<K> resolver;
 
   /// Compile-time define key, defaults to [EnvxConstants.defaultDefineKey].
   final String defineKey;
@@ -21,7 +21,7 @@ class EnvironmentService<E extends Enum, C> {
   ///
   /// Parameters:
   /// - [registry]: map of environments to configs, with a chosen default.
-  /// - [resolver]: function that maps string => enum (nullable result).
+  /// - [resolver]: function that maps string => key (nullable result).
   /// - [defineKey]: optional override for the compile-time define key.
   const EnvironmentService({
     required this.registry,
@@ -30,7 +30,7 @@ class EnvironmentService<E extends Enum, C> {
   });
 
   /// Parse [raw] via [resolver], falling back to [registry.defaultEnvironment] if null/empty/unrecognized.
-  E resolveFromString(String? raw) {
+  K resolveFromString(String? raw) {
     if (raw == null) return registry.defaultEnvironment;
     final trimmed = raw.trim();
     if (trimmed.isEmpty) return registry.defaultEnvironment;
@@ -44,7 +44,7 @@ class EnvironmentService<E extends Enum, C> {
   /// - [fallbackValue]: optional raw value used if the define is empty.
   ///
   /// Never throws. If it can't resolve, it falls back to [registry.defaultEnvironment].
-  E resolveFromBuildDefine({String? key, String? fallbackValue}) {
+  K resolveFromBuildDefine({String? key, String? fallbackValue}) {
     final k = (key == null || key.isEmpty) ? defineKey : key;
     // Note: `String.fromEnvironment` is evaluated at compile time.
     const empty = '';
@@ -58,7 +58,7 @@ class EnvironmentService<E extends Enum, C> {
   /// Get configuration for [env] with fallback to default.
   ///
   /// May return `null` if neither the requested nor default configs exist in the registry.
-  Future<C>? configFor(E env) => registry.tryGetOrDefault(env);
+  Future<C>? configFor(K env) => registry.tryGetOrDefault(env);
 
   /// Convenience: resolve environment from a string and return its config.
   Future<C>? configFromString(String? raw) {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,8 +1,8 @@
-/// Signature for functions that map a raw environment string to an enum value.
+/// Signature for functions that map a raw environment string to a typed key.
 ///
 /// Must return `null` if the input cannot be resolved.
 /// Do **not** throw for control flow – envx will safely fall back.
-typedef EnvResolver<E extends Enum> = E? Function(String input);
+typedef EnvResolver<K> = K? Function(String input);
 
 /// Constants used by the library. Keep magic strings out of the code.
 abstract final class EnvxConstants {

--- a/test/envx_test.dart
+++ b/test/envx_test.dart
@@ -1,0 +1,52 @@
+import 'package:envx/envx.dart';
+import 'package:test/test.dart';
+
+enum TestEnv { dev, prod }
+
+class TestConfig {
+  const TestConfig(this.value);
+  final String value;
+}
+
+TestEnv? parse(String input) {
+  switch (input) {
+    case 'prod':
+      return TestEnv.prod;
+    case 'dev':
+      return TestEnv.dev;
+    default:
+      return null;
+  }
+}
+
+void main() {
+  test('resolves current and specific environments', () async {
+    final env = Environment<TestEnv, TestConfig>(
+      configs: {
+        TestEnv.dev: () async => const TestConfig('dev'),
+        TestEnv.prod: () async => const TestConfig('prod'),
+      },
+      resolver: parse,
+      defaultEnvironment: TestEnv.dev,
+    );
+
+    expect(env.currentKey(fallbackValue: 'prod'), TestEnv.prod);
+
+    final cfg = await env.current(fallbackValue: 'prod');
+    expect(cfg?.value, 'prod');
+
+    final devCfg = await env.getEnvironment('dev');
+    expect(devCfg?.value, 'dev');
+  });
+
+  test('falls back to default when resolver misses', () async {
+    final env = Environment<TestEnv, TestConfig>(
+      configs: {TestEnv.dev: () async => const TestConfig('dev')},
+      resolver: parse,
+      defaultEnvironment: TestEnv.dev,
+    );
+
+    final cfg = await env.getEnvironment('unknown');
+    expect(cfg?.value, 'dev');
+  });
+}


### PR DESCRIPTION
## Summary
- add `Environment` factory to resolve configs without globals
- support generic environment keys in registry and service
- refresh documentation, example, and tests

## Testing
- `dart analyze`
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_68c0376f79a08325b5d9196d209a70ab