### PR TITLE
feat: add typed and string environment factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AppEnvironment? parseEnv(String value) {
 }
 
 Future<void> main() async {
-  final env = Environment.register<AppEnvironment, ExampleConfig>(
+  final env = Environment.register(
     configuration: {
       AppEnvironment.development:
           () async => const ExampleConfig('https://dev.example.com'),

--- a/example/envx_example.dart
+++ b/example/envx_example.dart
@@ -21,7 +21,7 @@ AppEnvironment? parseEnv(String value) {
 }
 
 Future<void> main() async {
-  final env = Environment.register<AppEnvironment, ExampleConfig>(
+  final env = Environment.register(
     configuration: {
       AppEnvironment.development: () async =>
           const ExampleConfig('https://dev.example.com'),

--- a/lib/envx.dart
+++ b/lib/envx.dart
@@ -47,18 +47,24 @@ class EnvironmentInstance<K, C> {
 /// Environment using `String` keys. The resolver is optional and defaults to
 /// the identity function.
 class StringEnvironment<C> extends EnvironmentInstance<String, C> {
+  // ignore: use_super_parameters
   StringEnvironment._(EnvironmentService<String, C> service) : super._(service);
 }
 
-/// Environment backed by an enum key. A resolver is required to translate raw
-/// strings to enum values.
-class TypedEnvironment<K extends Enum, C> extends EnvironmentInstance<K, C> {
+/// Environment backed by a non-string key. A resolver is required to translate
+/// raw strings to those keys.
+class TypedEnvironment<K, C> extends EnvironmentInstance<K, C> {
+  // ignore: use_super_parameters
   TypedEnvironment._(EnvironmentService<K, C> service) : super._(service);
 }
 
 /// Factory for creating typed or non-typed [EnvironmentInstance]s.
 abstract final class Environment {
   /// Register an environment.
+  ///
+  /// Generic parameters [K] and [C] are typically inferred from
+  /// [configuration] and [defaultEnvironment]; explicit type arguments are
+  /// only needed for unusual cases.
   ///
   /// Parameters:
   /// - [configuration]: mapping from environment keys to async configuration

--- a/test/envx_test.dart
+++ b/test/envx_test.dart
@@ -21,7 +21,7 @@ TestEnv? parse(String input) {
 
 void main() {
   test('resolves current and specific environments', () async {
-    final env = Environment.register<TestEnv, TestConfig>(
+    final env = Environment.register(
       configuration: {
         TestEnv.dev: () async => const TestConfig('dev'),
         TestEnv.prod: () async => const TestConfig('prod'),
@@ -40,7 +40,7 @@ void main() {
   });
 
   test('falls back to default when resolver misses', () async {
-    final env = Environment.register<TestEnv, TestConfig>(
+    final env = Environment.register(
       configuration: {TestEnv.dev: () async => const TestConfig('dev')},
       resolver: parse,
       defaultEnvironment: TestEnv.dev,
@@ -51,10 +51,8 @@ void main() {
   });
 
   test('string environments work without resolver', () async {
-    final env = Environment.register<String, TestConfig>(
-      configuration: {
-        'dev': () async => const TestConfig('dev'),
-      },
+    final env = Environment.register(
+      configuration: {'dev': () async => const TestConfig('dev')},
       defaultEnvironment: 'dev',
     );
 
@@ -64,7 +62,7 @@ void main() {
 
   test('throws when typed environment lacks resolver', () {
     expect(
-      () => Environment.register<TestEnv, TestConfig>(
+      () => Environment.register(
         configuration: {TestEnv.dev: () async => const TestConfig('dev')},
         defaultEnvironment: TestEnv.dev,
       ),


### PR DESCRIPTION
## Summary
- add factory `Environment.register` for creating string or enum-based environments
- introduce `StringEnvironment` and `TypedEnvironment` wrappers
- cover string and resolver validation in tests and docs

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c041ee02a8832597f4bb1a40ca74d4